### PR TITLE
Feature/pen 1886 removing Confirmed list logic and confirmed list section within .PAR template. 

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/penreg/api/mappers/v1/PenRequestBatchReportDataDecorator.java
+++ b/api/src/main/java/ca/bc/gov/educ/penreg/api/mappers/v1/PenRequestBatchReportDataDecorator.java
@@ -114,18 +114,7 @@ public abstract class PenRequestBatchReportDataDecorator implements PenRequestBa
       log.error("Error attempting to create report data. Students list should not be null for USR_MATCHED status.");
       return;
     }
-    val matchedStudent = students.get(penRequestBatchStudent.getStudentID());
-    if (matchedStudent != null && matchedStudent.getDemogCode() != null && matchedStudent.getDemogCode().equals(StudentDemogCode.CONFIRMED.getCode())) {
-      val item = listItemMapper.toReportUserMatchedListItem(penRequestBatchStudent, matchedStudent);
-      // override the value here. see https://gww.jira.educ.gov.bc.ca/browse/PEN-1523
-      // since student wont have full usual name , system overrides it from request student data in the batch file.
-      if (StringUtils.isNotBlank(item.getMin().getUsualName())) {
-        item.getMin().setUsualName(listItemMapper.populateUsualName(penRequestBatchStudent.getUsualLastName(), penRequestBatchStudent.getUsualFirstName(), penRequestBatchStudent.getUsualMiddleNames()));
-      }
-      confirmedList.add(item);
-    } else {
       addToSysMatchOrDiffList(sysMatchedList, diffList, students, penRequestBatchStudent);
-    }
   }
 
   private void populateForSystemMatchedStatus(final List<ReportListItem> sysMatchedList, final List<ReportUserMatchedListItem> diffList, final Map<String, Student> students, final PenRequestBatchStudent penRequestBatchStudent) {

--- a/api/src/main/resources/templates/PEN_REG_BATCH_RESPONSE_REPORT_PAR.txt
+++ b/api/src/main/resources/templates/PEN_REG_BATCH_RESPONSE_REPORT_PAR.txt
@@ -75,19 +75,7 @@ have the old PEN nulled by your MyEd HelpDesk.
 [# th:with="pen=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.pen, 9)},surname=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.surname, 25)},givenName=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.givenName, 25)},legalMiddleNames=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.legalMiddleNames, 25)},birthDate=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.birthDate, 10)},gender=${T(org.apache.commons.lang3.StringUtils).rightPad(diff.min.gender, 2)}" ]Min [(${pen})] [(${surname})] [(${givenName})] [(${legalMiddleNames})] [(${birthDate})] [(${gender})] [(${diff.min.schoolID})][/]
 
 [/]----------------------------------------------------------------------------------------------------------------------[/]
-[# th:if="${d.confirmedList.size() > 0}"]
-CONFIRMED – The record you submitted has matched an Official Ministry Record, however your record differs from the
-Official Ministry Record which has been confirmed with legal documentation. PLEASE update your record with the
-information from the Official Ministry Record or fax the PEN Coordinator any legal documentation that indicates the
-record you submitted is correct.
 
-       PEN    Legal Surname             Legal Given Name          Legal Middle Names        Birth Date Gn School Id
-    --------- ------------------------- ------------------------- ------------------------- ---------- -- ------------
-[# th:each="confirmed : ${d.confirmedList}"]
-[# th:with="pen=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.pen, 9)},surname=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.surname, 25)},givenName=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.givenName, 25)},legalMiddleNames=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.legalMiddleNames, 25)},birthDate=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.birthDate, 10)},gender=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.school.gender, 2)}" ]SCH [(${pen})] [(${surname})] [(${givenName})] [(${legalMiddleNames})] [(${birthDate})] [(${gender})] [(${confirmed.school.schoolID})][/]
-[# th:with="pen=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.pen, 9)},surname=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.surname, 25)},givenName=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.givenName, 25)},legalMiddleNames=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.legalMiddleNames, 25)},birthDate=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.birthDate, 10)},gender=${T(org.apache.commons.lang3.StringUtils).rightPad(confirmed.min.gender, 2)}" ]MIN [(${pen})] [(${surname})] [(${givenName})] [(${legalMiddleNames})] [(${birthDate})] [(${gender})] [(${confirmed.min.schoolID})][/]
-
-[/]----------------------------------------------------------------------------------------------------------------------[/]
 The PEN request file was processed by the PEN system on [(${d.processDate})] at [(${d.processTime})], PENWEB Submission #[(${d.submissionNumber})]
 
 END OF REPORT

--- a/api/src/test/java/ca/bc/gov/educ/penreg/api/mapper/v1/PenRequestBatchReportDataMapperTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/penreg/api/mapper/v1/PenRequestBatchReportDataMapperTest.java
@@ -69,48 +69,47 @@ public class PenRequestBatchReportDataMapperTest extends BasePenRegAPITest {
     assertThat(reportData.getMailingAddress()).isEqualTo("mailing address");
     assertThat(reportData.getPenCordinatorEmail()).isEqualTo("test@abc.com");
 
-    assertThat(reportData.getDiffList().size()).isEqualTo(1);
-    assertThat(reportData.getDiffList().get(0).getMin().getBirthDate()).isEqualTo("1990/07/03");
-    assertThat(reportData.getDiffList().get(0).getMin().getGender()).isEqualTo("F");
-    assertThat(reportData.getDiffList().get(0).getMin().getGivenName()).isEqualTo("Ted");
-    assertThat(reportData.getDiffList().get(0).getMin().getLegalMiddleNames()).isEqualTo("Jim");
-    assertThat(reportData.getDiffList().get(0).getMin().getPen()).isEqualTo("123456780");
+    assertThat(reportData.getDiffList().size()).isEqualTo(2);
+    assertThat(reportData.getDiffList().get(0).getMin().getBirthDate()).isEqualTo("1990/07/04");
+    assertThat(reportData.getDiffList().get(0).getMin().getGender()).isEqualTo("M");
+    assertThat(reportData.getDiffList().get(0).getMin().getGivenName()).isEqualTo("Mike");
+    assertThat(reportData.getDiffList().get(0).getMin().getLegalMiddleNames()).isEqualTo("Tim");
+    assertThat(reportData.getDiffList().get(0).getMin().getPen()).isEqualTo("123456785");
     assertThat(reportData.getDiffList().get(0).getMin().getReason()).isNull();
     assertThat(reportData.getDiffList().get(0).getMin().getSchoolID()).isBlank();
-    assertThat(reportData.getDiffList().get(0).getMin().getSurname()).isEqualTo("Jones");
-    assertThat(reportData.getDiffList().get(0).getMin().getUsualName()).isEqualTo("JOSEPH, BRAYDON, SMIT");
+    assertThat(reportData.getDiffList().get(0).getMin().getSurname()).isEqualTo("Joe");
+    assertThat(reportData.getDiffList().get(0).getMin().getUsualName()).isEqualTo("JOSEPH, BRAYDON, KIM");
 
     assertThat(reportData.getDiffList().get(0).getSchool().getBirthDate()).isEqualTo("2011/12/08");
     assertThat(reportData.getDiffList().get(0).getSchool().getGender()).isEqualTo("M");
-    assertThat(reportData.getDiffList().get(0).getSchool().getGivenName()).isEqualTo("BOY");
+    assertThat(reportData.getDiffList().get(0).getSchool().getGivenName()).isEqualTo("BRAYDON");
     assertThat(reportData.getDiffList().get(0).getSchool().getLegalMiddleNames()).isEqualTo("JAMIESON");
-    assertThat(reportData.getDiffList().get(0).getSchool().getPen()).isEqualTo("987654321");
-    assertThat(reportData.getDiffList().get(0).getSchool().getReason()).isEqualTo("Here's some more info");
+    assertThat(reportData.getDiffList().get(0).getSchool().getPen()).isEqualTo("123456785");
+    assertThat(reportData.getDiffList().get(0).getSchool().getReason()).isEqualTo("Here's some info");
     assertThat(reportData.getDiffList().get(0).getSchool().getSchoolID()).isEqualTo("2046302");
-    assertThat(reportData.getDiffList().get(0).getSchool().getSurname()).isEqualTo("BRODY");
-    assertThat(reportData.getDiffList().get(0).getSchool().getUsualName()).isEqualTo("JOSEPH, BRAYDON, SMIT");
+    assertThat(reportData.getDiffList().get(0).getSchool().getSurname()).isEqualTo("JOSEPH");
+    assertThat(reportData.getDiffList().get(0).getSchool().getUsualName()).isEqualTo("JOSEPH, BRAYDON, KIM");
 
-    assertThat(reportData.getConfirmedList().size()).isEqualTo(1);
-    assertThat(reportData.getConfirmedList().get(0).getMin().getBirthDate()).isEqualTo("1990/07/04");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getGender()).isEqualTo("M");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getGivenName()).isEqualTo("Mike");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getLegalMiddleNames()).isEqualTo("Tim");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getPen()).isEqualTo("123456785");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getReason()).isNull();
-    assertThat(reportData.getConfirmedList().get(0).getMin().getSchoolID()).isBlank();
-    assertThat(reportData.getConfirmedList().get(0).getMin().getSurname()).isEqualTo("Joe");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getUsualName()).isEqualTo("JOSEPH, BRAYDON, KIM");
+    assertThat(reportData.getDiffList().size()).isEqualTo(2);
+    assertThat(reportData.getDiffList().get(1).getMin().getBirthDate()).isEqualTo("1990/07/03");
+    assertThat(reportData.getDiffList().get(1).getMin().getGender()).isEqualTo("F");
+    assertThat(reportData.getDiffList().get(1).getMin().getGivenName()).isEqualTo("Ted");
+    assertThat(reportData.getDiffList().get(1).getMin().getLegalMiddleNames()).isEqualTo("Jim");
+    assertThat(reportData.getDiffList().get(1).getMin().getPen()).isEqualTo("123456780");
+    assertThat(reportData.getDiffList().get(1).getMin().getReason()).isNull();
+    assertThat(reportData.getDiffList().get(1).getMin().getSchoolID()).isBlank();
+    assertThat(reportData.getDiffList().get(1).getMin().getSurname()).isEqualTo("Jones");
+    assertThat(reportData.getDiffList().get(1).getMin().getUsualName()).isEqualTo("JOSEPH, BRAYDON, SMIT");
 
-    assertThat(reportData.getConfirmedList().size()).isEqualTo(1);
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getBirthDate()).isEqualTo("2011/12/08");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getGender()).isEqualTo("M");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getGivenName()).isEqualTo("BRAYDON");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getLegalMiddleNames()).isEqualTo("JAMIESON");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getPen()).isEqualTo("123456785");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getReason()).isEqualTo("Here's some info");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getSchoolID()).isEqualTo("2046302");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getSurname()).isEqualTo("JOSEPH");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getUsualName()).isEqualTo("JOSEPH, BRAYDON, KIM");
+    assertThat(reportData.getDiffList().get(1).getSchool().getBirthDate()).isEqualTo("2011/12/08");
+    assertThat(reportData.getDiffList().get(1).getSchool().getGender()).isEqualTo("M");
+    assertThat(reportData.getDiffList().get(1).getSchool().getGivenName()).isEqualTo("BOY");
+    assertThat(reportData.getDiffList().get(1).getSchool().getLegalMiddleNames()).isEqualTo("JAMIESON");
+    assertThat(reportData.getDiffList().get(1).getSchool().getPen()).isEqualTo("987654321");
+    assertThat(reportData.getDiffList().get(1).getSchool().getReason()).isEqualTo("Here's some more info");
+    assertThat(reportData.getDiffList().get(1).getSchool().getSchoolID()).isEqualTo("2046302");
+    assertThat(reportData.getDiffList().get(1).getSchool().getSurname()).isEqualTo("BRODY");
+    assertThat(reportData.getDiffList().get(1).getSchool().getUsualName()).isEqualTo("JOSEPH, BRAYDON, SMIT");
 
     assertThat(reportData.getNewPenList().size()).isEqualTo(2);
     assertThat(reportData.getPendingList().size()).isEqualTo(5);
@@ -226,31 +225,20 @@ public class PenRequestBatchReportDataMapperTest extends BasePenRegAPITest {
     assertThat(reportData.getDiffList().get(0).getSchool().getSurname()).isEqualTo("");
     assertThat(reportData.getDiffList().get(0).getSchool().getUsualName()).isEqualTo("");
 
-    assertThat(reportData.getConfirmedList().size()).isEqualTo(1);
-    assertThat(reportData.getConfirmedList().get(0).getMin().getBirthDate()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getGender()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getGivenName()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getLegalMiddleNames()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getPen()).isEqualTo("123456785");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getReason()).isEqualTo(null);
-    assertThat(reportData.getConfirmedList().get(0).getMin().getSchoolID()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getSurname()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getMin().getUsualName()).isEqualTo("");
-
-    assertThat(reportData.getConfirmedList().size()).isEqualTo(1);
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getBirthDate()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getGender()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getGivenName()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getLegalMiddleNames()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getPen()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getReason()).isEqualTo(null);
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getSchoolID()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getSurname()).isEqualTo("");
-    assertThat(reportData.getConfirmedList().get(0).getSchool().getUsualName()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().size()).isEqualTo(2);
+    assertThat(reportData.getSysMatchedList().get(1).getBirthDate()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getGender()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getGivenName()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getLegalMiddleNames()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getPen()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getReason()).isEqualTo(null);
+    assertThat(reportData.getSysMatchedList().get(1).getSchoolID()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getSurname()).isEqualTo("");
+    assertThat(reportData.getSysMatchedList().get(1).getUsualName()).isEqualTo("");
 
     assertThat(reportData.getNewPenList().size()).isEqualTo(2);
     assertThat(reportData.getPendingList().size()).isEqualTo(4);
-    assertThat(reportData.getSysMatchedList().size()).isEqualTo(1);
+    assertThat(reportData.getSysMatchedList().size()).isEqualTo(2);
   }
 
     public String formatMincode(String mincode) {


### PR DESCRIPTION
PenRequestBatchReportDataDecorator.java
-removed logic sending data to confirmed list. 

PEN_REG_BATCH_RESPONSE_REPORT_PAR.txt 
-changed template to remove confirmed list section 

PenRequestBatchReportDataMapperTest.java
I changed 2 tests

1. Line 34  public void testToReportUserMatchedListItem_GivenAllValues_ShouldMapSuccessfully 

student1 normally gets sent to confirmed list, however it now gets sent to diffList. The diffList size increased from 1 to 2. 

I had to change the ordering for the diff list test (which is why there are so many edits in the asserts here. 
student1 is in reportData.getDiffList().get(0). 

student2 is in reportData.getDiffLIst().get(1) <-- this used to be in getDiffList().get(0). 

2. Line 171  public void testToReportUserMatchedListItem_GivenNullValues_ShouldMapSuccessfully()

what was sent to ConfirmedList now gets sent to SysMatchedList. So the size gets increased from 1 -> 2. 

Since SysMatchedList is for exact matches it does not have a ministry/school information. Therefore, I had to remove .getMin and .getSchool from the test. 
